### PR TITLE
Add Zentropi to RMC Partners list

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Although there are many open safety models, we hold a specific bar for RMC Partn
 
 - OpenAI: [gpt-oss-safeguard](https://huggingface.co/collections/openai/gpt-oss-safeguard)
 
+- Zentropi: [CoPE-B-A4B](https://huggingface.co/zentropi-ai/cope-b-a4b)
+
 RMC Partners receive a variety of benefits, including:
 
 - Promotion of their model (e.g., via demos during Office Hours, support on events)


### PR DESCRIPTION
## Summary
- Adds Zentropi ([CoPE-B-A4B](https://huggingface.co/zentropi-ai/cope-b-a4b)) to the list of RMC Partner models in the README.

## Test plan
- [ ] Link renders correctly on GitHub