### PR TITLE
docs: Update README with Mila partnership and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ This repository serves as the home to find resources for the community, includin
 
 You can browse the current resources directly on GitHub:
 
-- [gpt-oss-safeguard/](gpt-oss-safeguard): Resources and projects related to OpenAI's bring your own policy safety reasoning model
 - [cope-b/](cope-b): Resources and projects related to Zentropi's bring your own policy safety model
+- [gpt-oss-safeguard/](gpt-oss-safeguard): Resources and projects related to OpenAI's bring your own policy safety reasoning model
+- [mila/](mila): Resources and projects related to Mila's suicide-asisstance prevention guardrail
 - [projects/](projects): Interesting demos that are not RMC-model-specific
 - [resources/](resources): Community-wide resources for using open safety models, not tied to any single RMC Partner. Includes:
   - [RMC Guide to Using Open Safety Models](resources/RMC%20Guide%20to%20Using%20Open%20Safety%20Models.md) — an introduction to applying open safety models across the Detection, Investigation, Review, and Enforcement stages of a T&S architecture
@@ -58,6 +59,7 @@ Although there are many open safety models, we hold a specific bar for RMC Partn
 
 ## RMC Partners
 
+- Mila: [Mila-Suicide-Prevention-Output-Guardrail](https://huggingface.co/mila-ai4h/Mila-Suicide-Prevention-Output-Guardrail)
 - OpenAI: [gpt-oss-safeguard](https://huggingface.co/collections/openai/gpt-oss-safeguard)
 - Zentropi: [CoPE-B-A4B](https://huggingface.co/zentropi-ai/cope-b-a4b)
 


### PR DESCRIPTION
Follow-up to #87 to add to the README

- Alphabetized the "navigating this repo" links
- Added link to `mila/` folder to that section
- Added Mila under RMC partners, linking to Hugging Face like the others