### PR TITLE
add shieldstral

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ You can browse the current resources directly on GitHub:
 - [cope-b/](cope-b): Resources and projects related to Zentropi's bring your own policy safety model
 - [gpt-oss-safeguard/](gpt-oss-safeguard): Resources and projects related to OpenAI's bring your own policy safety reasoning model
 - [mila/](mila): Resources and projects related to Mila's suicide-asisstance prevention guardrail
+- [Shieldstral 1.0 3B](shieldstral): Resources and links related to Mistral's Shieldstral 1.0 3B model
 - [projects/](projects): Interesting demos that are not RMC-model-specific
 - [resources/](resources): Community-wide resources for using open safety models, not tied to any single RMC Partner. Includes:
   - [RMC Guide to Using Open Safety Models](resources/RMC%20Guide%20to%20Using%20Open%20Safety%20Models.md) — an introduction to applying open safety models across the Detection, Investigation, Review, and Enforcement stages of a T&S architecture

--- a/shieldstral/README.md
+++ b/shieldstral/README.md
@@ -1,0 +1,7 @@
+# Shieldstral 1.0 3B
+
+- [Download Shieldstral 1.0 3B on HuggingFace](https://huggingface.co/mistralai/Shieldstral-1.0-3B)
+- [Mistral Announcement](https://mistral.ai/news/shieldstral/)
+- [ROOST Announcement](https://roost.tools/blog/welcoming-mistral-ai-s-shieldstral-to-the-roost-model-community/)
+- [Model Card](https://huggingface.co/mistralai/Shieldstral-1.0-3B)
+

--- a/shieldstral/README.md
+++ b/shieldstral/README.md
@@ -4,4 +4,5 @@
 - [Mistral Announcement](https://mistral.ai/news/shieldstral/)
 - [ROOST Announcement](https://roost.tools/blog/welcoming-mistral-ai-s-shieldstral-to-the-roost-model-community/)
 - [Model Card](https://huggingface.co/mistralai/Shieldstral-1.0-3B)
+- [Technical report](https://arxiv.org/abs/2607.25857)
 


### PR DESCRIPTION
Adding Shieldstral to the RMC via the new partnership. Links to Mistral's announcement, ROOST's announcement, and Shieldstral's huggingface page.