### PR TITLE
Shieldstral: correct ROOST announcement link

### DIFF
--- a/shieldstral/README.md
+++ b/shieldstral/README.md
@@ -2,7 +2,7 @@
 
 - [Download Shieldstral 1.0 3B on HuggingFace](https://huggingface.co/mistralai/Shieldstral-1.0-3B)
 - [Mistral Announcement](https://mistral.ai/news/shieldstral/)
-- [ROOST Announcement](https://roost.tools/blog/welcoming-mistral-ai-s-shieldstral-to-the-roost-model-community/)
+- [ROOST Announcement](https://roost.tools/blog/mistral-shieldstral-joins-the-RMC/)
 - [Model Card](https://huggingface.co/mistralai/Shieldstral-1.0-3B)
 - [Technical report](https://arxiv.org/abs/2607.25857)
 


### PR DESCRIPTION
Pointed out by someone in the community that this URL was wrong.