### PR TITLE
README: alphabetize and standardize

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,15 @@ You can browse the current resources directly on GitHub:
 - [cope-b/](cope-b): Resources and projects related to Zentropi's bring your own policy safety model
 - [gpt-oss-safeguard/](gpt-oss-safeguard): Resources and projects related to OpenAI's bring your own policy safety reasoning model
 - [mila/](mila): Resources and projects related to Mila's suicide-asisstance prevention guardrail
-- [roblox-sentinel/](roblox-sentinel): Resources and links related to Roblox's Sentinel, a Python library for detecting extremely rare classes of text
-- [roblox-voice-safety-classifier/](roblox-voice-safety-classifier): Resources related to Roblox's voice safety classifier
-- [roblox-pii-classifier/](roblox-pii-classifier): Resources and projects related to Roblox's chat-based PII classifiers
-- [Shieldstral 1.0 3B](shieldstral): Resources and links related to Mistral's Shieldstral 1.0 3B model
 - [projects/](projects): Interesting demos that are not RMC-model-specific
 - [resources/](resources): Community-wide resources for using open safety models, not tied to any single RMC Partner. Includes:
   - [RMC Guide to Using Open Safety Models](resources/RMC%20Guide%20to%20Using%20Open%20Safety%20Models.md) — an introduction to applying open safety models across the Detection, Investigation, Review, and Enforcement stages of a T&S architecture
   - [policy-packs/](resources/policy-packs) — partner-contributed policy prompt packs, organized by submitter, that can be used directly with policy-following open safety models
   - Other code snippets and supplementary materials for non-RMC models
+- [roblox-pii-classifier/](roblox-pii-classifier): Resources and projects related to Roblox's chat-based PII classifiers
+- [roblox-sentinel/](roblox-sentinel): Resources and links related to Roblox's Sentinel, a Python library for detecting extremely rare classes of text
+- [roblox-voice-safety-classifier/](roblox-voice-safety-classifier): Resources related to Roblox's voice safety classifier
+- [shieldstral/](shieldstral): Resources and links related to Mistral's policy-adaptive multimodal safety classifier
 
 ## Join us!
 
@@ -64,7 +64,9 @@ Although there are many open safety models, we hold a specific bar for RMC Partn
 ## RMC Partners
 
 - Mila: [Mila-Suicide-Prevention-Output-Guardrail](https://huggingface.co/mila-ai4h/Mila-Suicide-Prevention-Output-Guardrail)
+- Mistral: [Shieldstral-1.0-3B](https://huggingface.co/mistralai/Shieldstral-1.0-3B)
 - OpenAI: [gpt-oss-safeguard](https://huggingface.co/collections/openai/gpt-oss-safeguard)
+- Roblox: [Sentinel](https://github.com/Roblox/Sentinel), [voice-safety-classifier-v3](https://huggingface.co/Roblox/voice-safety-classifier-v3), [roblox-pii-classifier-v2](https://huggingface.co/Roblox/roblox-pii-classifier-v2)
 - Zentropi: [CoPE-B-A4B](https://huggingface.co/zentropi-ai/cope-b-a4b)
 
 RMC Partners receive a variety of benefits, including:


### PR DESCRIPTION
- Alphabetize the folder listing
- Correct the Shieldstral folder name
- Add Mistral and Roblox to the RMC partners list